### PR TITLE
Clarify that RewriteRule E flag is unsupported, and fix some parsing cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ mod_negotiation	|	`ForceLanguagePriority`	|	No	|
 mod_negotiation	|	`LanguagePriority`	|	No	|	
 mod_reflector	|	`*`	|	Never	|	Security reasons
 mod_rewrite	|	`RewriteBase`	|	Yes	|	
-mod_rewrite	|	`RewriteCond`	|	Yes	|	
+mod_rewrite	|	`RewriteCond`	|	Partial	|	Environment (E=) flag is unsupported
 mod_rewrite	|	`RewriteEngine`	|	Yes	|	
 mod_rewrite	|	`RewriteOptions`	|	No	|	
 mod_rewrite	|	`RewriteRule`	|	Yes	|	

--- a/htaccess.lua
+++ b/htaccess.lua
@@ -748,13 +748,13 @@ local replace_server_vars = function(str, track_used_headers)
 		if first_five == 'http_' then -- %{HTTC_*}, e.g. %{HTTC_HOST}
 			replace = ngx.var[svar] or ''
 			if track_used_headers then
-				table.insert(used_headers, svar:sub(6):gsub('_', '-'):lower())
+				table.insert(used_headers, (svar:sub(6):gsub('_', '-'):lower()))
 			end
 		elseif first_five == 'http:' then -- %{HTTP:*}, e.g. %{HTTP:Content-Type}
 			svar = svar:sub(6):gsub('-','_'):lower()
 			replace = ngx.var['http_'..svar] or ''
 			if track_used_headers then
-				table.insert(used_headers, svar:gsub('_', '-'))
+				table.insert(used_headers, (svar:gsub('_', '-')))
 			end
 		elseif first_five == 'time_' then -- %{TIME_*}, e.g. %{TIME_YEAR}
 			svar = svar:sub(6)

--- a/htaccess.lua
+++ b/htaccess.lua
@@ -813,6 +813,8 @@ local current_dir
 local stat_instructions_used = {}
 local stat_blocks_used = {}
 for statement in htaccess:gmatch('[^\r\n]+') do
+	-- Trim leading whitespace
+	statement = statement:gsub("^%s*", "");
 	if statement:sub(1,1) == '<' then
 		-- handle blocks
 		if statement:sub(2,2) ~= '/' then

--- a/htaccess.lua
+++ b/htaccess.lua
@@ -815,7 +815,10 @@ local stat_blocks_used = {}
 for statement in htaccess:gmatch('[^\r\n]+') do
 	-- Trim leading whitespace
 	statement = statement:gsub("^%s*", "");
-	if statement:sub(1,1) == '<' then
+
+	if statement:sub(1,1) == '#' then
+		-- Comment, so ignore it
+	elseif statement:sub(1,1) == '<' then
 		-- handle blocks
 		if statement:sub(2,2) ~= '/' then
 			-- opening tag <...>
@@ -989,6 +992,7 @@ for statement in htaccess:gmatch('[^\r\n]+') do
 				pop_ctx()
 			end
 		end
+
 	else
 		local instruction = statement:match('^[^%s]+')
 		if instruction then
@@ -1209,11 +1213,9 @@ if get_cdir('rewrite') and #parsed_rewriterules > 0 then
 					elseif flag == 'qsa' or flag == 'qsappend' then -- [QSA]
 						local qs = relative_uri:match('%?.*')
 						if qs then
-							local new_qs = dst:match('%?.*')
+							local new_qs = dst:match('%?.*')					
 							if new_qs then
 								dst = dst:gsub('%?.*', '', 1)..qs..'&'..new_qs:sub(2)
-							else
-								dst = dst..new_qs
 							end
 						end
 					elseif flag == 'qsd' or flag == 'qsdiscard' then -- [QSD]

--- a/htaccess.lua
+++ b/htaccess.lua
@@ -1222,6 +1222,10 @@ if get_cdir('rewrite') and #parsed_rewriterules > 0 then
 						else
 							fail('Invalid flag value: ['..rawflag..'], expecting a number')
 						end
+					elseif flag == 'e' then -- [E=]
+						-- Trying to set or unset an environment variable
+						-- https://httpd.apache.org/docs/2.4/rewrite/flags.html
+						fail('RewriteRule flag E is unsupported')
 					else
 						fail('Unsupported RewriteRule flag: '..flag)
 					end


### PR DESCRIPTION
I don't think it's possible to set/unset environment variables due to the explanation in https://stackoverflow.com/questions/8098927/nginx-variables-similar-to-setenv-in-apache/8099167#8099167, so this clarifies the lack of E (Environment) flag support in the README and code. 

Also, I discovered that the parsing failed if there was leading whitespace, so, for example:

"  RewriteRule .* /redirect-me"

would not get processed but

"RewriteRule .* /redirect-me"

would, even though both are valid syntax. This PR trims leading whitespace on all statements to make them both parse the same.  I suspect that the leading whitespace may be the cause of https://github.com/e404/htaccess-for-nginx/issues/7 BTW.