### PR TITLE
fix: assure appended .htaccess files starts on a new line

### DIFF
--- a/htaccess.lua
+++ b/htaccess.lua
@@ -217,7 +217,7 @@ if not htaccess then
 				fail(C_SECURITY_VIOLATION_ERROR)
 			end
 			local relative_dir = last_htaccess_dir:sub(rootpath:len()+1)
-			htaccess = C_DIR..' '..relative_dir..'\n'..htaccess..current_htaccess
+			htaccess = C_DIR..' '..relative_dir..'\n'..htaccess..current_htaccess..'\n'
 		end
 	end
 	read_htaccess() -- process file in root directory first


### PR DESCRIPTION
This is a fix for the issue #14 (Error when handling commented .htaccess files).

Appending a `..'\n'` before concatenating each new .htaccess file content will ensure it starts on a new line, thus preventing the issue mentioned above.