### PR TITLE
Fix replacement logic in replace_server_args (ensure replacement does not use capture indexes)

### DIFF
--- a/htaccess.lua
+++ b/htaccess.lua
@@ -912,7 +912,7 @@ for statement in htaccess:gmatch('[^\r\n]+') do
 							-- TODO: Add match as environment variable
 							-- <FilesMatch "^(?<sitename>[^/]+)"> ==> %{env:MATCH_SITENAME}
 						end
-					elseif request_filename == test or request_filename:match(test:gsub('%.', '%.'):gsub('%?', '.'):gsub('*', '.+')) then
+					elseif request_filename ~= nil and (request_filename == test or request_filename:match(test:gsub('%.', '%.'):gsub('%?', '.'):gsub('*', '.+'))) then
 						use_block = true
 					end
 				elseif tag_name == 'limit' or tag_name == 'limitexcept' then

--- a/htaccess.lua
+++ b/htaccess.lua
@@ -806,7 +806,7 @@ local replace_server_vars = function(str, track_used_headers)
 		elseif svar == 'time' then -- %{TIME}
 			replace = os.date('%Y%m%d%H%M%S')
 		end
-		result = result:gsub('%%{'..org_svar..'}', replace)..''
+		result = result:gsub('%%{'..org_svar..'}', replace:gsub('%%', '%%%%')..'')..''  -- make sure no capture indexes are being used as replacement
 	end
 	if track_used_headers then
 		return result, used_headers


### PR DESCRIPTION
When using unfiltered string as replacement, it is important to escape the `%` characters to prevent "invalid capture index" errors. This is properly done in:

- https://github.com/e404/htaccess-for-nginx/blob/ec2de6a3cd58df5584fd929d178a43e8e1a167ca/htaccess.lua#L1290
- https://github.com/e404/htaccess-for-nginx/blob/ec2de6a3cd58df5584fd929d178a43e8e1a167ca/htaccess.lua#L1296

But not here:

- https://github.com/e404/htaccess-for-nginx/blob/ec2de6a3cd58df5584fd929d178a43e8e1a167ca/htaccess.lua#L809

Consider this rewrite rule set, which is modified from Wordpress default:

```
<IfModule mod_rewrite.c>
RewriteEngine On
# RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
RewriteBase /
RewriteRule ^index\.php$ - [L]
RewriteCond %{REQUEST_FILENAME} !-f
RewriteCond %{REQUEST_FILENAME} !-d
RewriteRule . /index.php?%{QUERY_STRING} [L]
</IfModule>
```

If the last rule is triggered with query string that contains something like `%2C`, the script will crash. This commit fixes it by also doing `replace:gsub('%%', '%%%%')..''`.

---

The second commit fixed #37. I accidentally committed it to the same branch.